### PR TITLE
Fix errors and improve the clarity in readme.txt

### DIFF
--- a/csmatio/readme.txt
+++ b/csmatio/readme.txt
@@ -1,20 +1,15 @@
 CSMatIO is a .NET Library to read, write, and manipulate Matlab binary
 MAT-files.
 
-CSMatIO is a managed version of the Matlab MAT-File I/O API written entirly in C#.  As is with
-most of my projects, CSMatIO was originally intended as a small support application for my Ph.D.
-research, but quickly grew out of control into a full API.  CSMatIO was orinally based off of 
-converting the Java source code to C# from the JMatIO library written by Wojciech Gradkowski, 
-but eventually grew morphed into its current version.  Mr. Gradkowski's CSMatIO is, I am sure,
-an excellent utility, but unfortionately is imcompatable with Microsoft's .NET Architecture.
+CSMatIO is a managed version of the Matlab MAT-File I/O API written entirely in C#.  As is with most of my projects, CSMatIO based initially on converting the Java source code to C# from the JMatIO library that is written by Wojciech Gradkowski. It was used as a small support application for my Ph.D. research, but quickly grew out of control into a full API. 
+Mr. Gradkowski's CSMatIO is an excellent utility but unfortunately is incompatible with Microsoft's .NET Architecture.
 
-This library was written for people who develope .NET applications and would like to import or
-export there data into Matlab for further processing or to use Matlabs superior graphing 
-capabilities.  It was written with Visual Studio .NET 2005 and requires the .NET 2.0 
+This library is for people who are developing .NET applications and would like to import or export their data into Matlab for further processing or to use Matlabs superior graphing capabilities.  It was written with Visual Studio .NET 2005 and required the .NET 2.0 
 Architecture set to be installed.
 
-If you would like to send comments, improvement requests, or to criticize the project please 
-email me: david.zier@gmail.com 
+If you would like to send comments, improvement requests, or to criticize the project, please
+email me:  david.zier@gmail.com 
+
 
 Enjoy!
 


### PR DESCRIPTION
"entirly"-->"entirely"
"orinally"-->"originally"
"unfortionately" -->"unfortunately"
"develope"-->"is developing"
"imcompatable"-->"imcompatible"
"there"--> "their"

Combined two sentences that both start from "CSMatIO was originally " to reduce monotony. 

Deleted "I am sure" to make the sentence more concise. 

modified some unnecessary words to increase the clarity of the sentences.For example,  "based off of" was changed to " based on". 
